### PR TITLE
Make the Open Graph image work when sharing.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,13 +8,13 @@
     <meta property="og:url" content="https://abbrevia.me">
     <meta property="og:title" content="abbrevia.me">
     <meta property="og:description" content="abbreviate users' information from their latest tweets.">
-    <meta property="og:image" content="./destacada.jpg">
+    <meta property="og:image" content="https://raw.githubusercontent.com/heedrox/abbreviame/main/public/destacada.jpg">
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://abbrevia.me">
     <meta property="twitter:title" content="abbrevia.me">
     <meta property="twitter:description" content="abbreviate users' information from their latest tweets.">
-    <meta property="twitter:image" content="./destacada.jpg">
+    <meta property="twitter:image" content="https://raw.githubusercontent.com/heedrox/abbreviame/main/public/destacada.jpg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css"
       integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
     <title>abbrevia.me: abbreviate users' information from their latest tweets.</title>


### PR DESCRIPTION
Make the image work when sharing the web link.

In this case, you can't use a relative path. It must be an absolute path. Now it should work.